### PR TITLE
Fix binary file mode in VHSB file I/O operations

### DIFF
--- a/+vlt/+file/+custom_file_formats/vhsb_write.m
+++ b/+vlt/+file/+custom_file_formats/vhsb_write.m
@@ -132,7 +132,7 @@ h = vlt.file.custom_file_formats.vhsb_writeheader(fo,parameters);
 
  % vlt.file.custom_file_formats.vhsb_writeheader will close the file
 
-fo = fopen(fo,'r+','ieee-le');
+fo = fopen(fo,'r+b','ieee-le');
 
 fseek(fo,h.headersize,'bof');
 

--- a/+vlt/+file/+custom_file_formats/vhsb_writeheader.m
+++ b/+vlt/+file/+custom_file_formats/vhsb_writeheader.m
@@ -82,7 +82,7 @@ end;
 
  % open file for writing, set machine-type to little-endian
 
-fo = fopen(fo,'w','ieee-le');
+fo = fopen(fo,'wb','ieee-le');
 
 fseek(fo, 0, 'bof');
 

--- a/file/custom_file_formats/vhsb_write.m
+++ b/file/custom_file_formats/vhsb_write.m
@@ -132,7 +132,7 @@ h = vhsb_writeheader(fo,parameters);
 
  % vhsb_writeheader will close the file
 
-fo = fopen(fo,'r+','ieee-le');
+fo = fopen(fo,'r+b','ieee-le');
 
 fseek(fo,h.headersize,'bof');
 

--- a/file/custom_file_formats/vhsb_writeheader.m
+++ b/file/custom_file_formats/vhsb_writeheader.m
@@ -82,7 +82,7 @@ end;
 
  % open file for writing, set machine-type to little-endian
 
-fo = fopen(fo,'w','ieee-le');
+fo = fopen(fo,'wb','ieee-le');
 
 fseek(fo, 0, 'bof');
 


### PR DESCRIPTION
## Summary
Updated file open modes in VHSB (MATLAB custom file format) read/write operations to explicitly specify binary mode, ensuring proper handling of binary data across different platforms.

## Key Changes
- Modified `vhsb_writeheader.m`: Changed `fopen()` mode from `'w'` to `'wb'` to explicitly open files in binary write mode
- Modified `vhsb_write.m`: Changed `fopen()` mode from `'r+'` to `'r+b'` to explicitly open files in binary read-write mode
- Applied changes to both the namespaced (`+vlt/+file/+custom_file_formats/`) and non-namespaced (`file/custom_file_formats/`) versions of the files

## Implementation Details
The addition of the `'b'` flag to the file open modes ensures that files are opened in binary mode, which is critical for:
- Preventing automatic line-ending conversions on Windows systems
- Maintaining data integrity when reading/writing binary file formats
- Ensuring consistent behavior across different operating systems

This is a best practice for binary file I/O in MATLAB, particularly important for custom binary file formats like VHSB.

https://claude.ai/code/session_01GUYMDWds1fmUhTL53QjsmH