### PR TITLE
findfilegroups: skip hidden directories by default

### DIFF
--- a/+vlt/+file/findfilegroups.m
+++ b/+vlt/+file/findfilegroups.m
@@ -31,6 +31,8 @@ function filelist = findfilegroups(parentdir, fileparameters, options)
 %  SearchParent (1)            | Should we search the parent?
 %  SearchDepth (Inf)           | How many directories 'deep' should we search?
 %                              |   0 means parent only, 1 means one folder in, ...
+%  followHidden (0)            | Should we traverse subdirectories whose names begin
+%                              |    with a '.' (hidden directories)?
 %
 %  Examples:
 %
@@ -67,6 +69,7 @@ arguments
     options.SearchParentFirst = 1
     options.SearchDepth = Inf
     options.SearchParent = 1
+    options.followHidden = 0
 end
 
 vlt.data.struct2var(options);
@@ -80,6 +83,12 @@ d = vlt.file.dirstrip(dir(parentdir));
 
 subdirs = find([d.isdir]);
 regularfiles = find(~[d.isdir]);
+
+if ~followHidden, % drop subdirectories whose names begin with '.'
+	subdirnames = {d(subdirs).name};
+	ishidden = ~cellfun(@isempty, regexp(subdirnames,'^\.','once'));
+	subdirs = subdirs(~ishidden);
+end;
 
 if ~SearchParentFirst,
 	for i=subdirs,

--- a/file/findfilegroups.m
+++ b/file/findfilegroups.m
@@ -31,6 +31,8 @@ function filelist = findfilegroups(parentdir, fileparameters, options)
 %  SearchParent (1)            | Should we search the parent?
 %  SearchDepth (Inf)           | How many directories 'deep' should we search?
 %                              |   0 means parent only, 1 means one folder in, ...
+%  followHidden (0)            | Should we traverse subdirectories whose names begin
+%                              |    with a '.' (hidden directories)?
 %
 %  Examples:
 %
@@ -67,6 +69,7 @@ function filelist = findfilegroups(parentdir, fileparameters, options)
         options.SearchParentFirst logical = true;
         options.SearchDepth (1,1) double = Inf;
         options.SearchParent logical = true;
+        options.followHidden logical = false;
     end
 
 filelist = {};
@@ -77,6 +80,12 @@ d = dirstrip(dir(parentdir));
 
 subdirs = find([d.isdir]);
 regularfiles = find(~[d.isdir]);
+
+if ~options.followHidden, % drop subdirectories whose names begin with '.'
+	subdirnames = {d(subdirs).name};
+	ishidden = ~cellfun(@isempty, regexp(subdirnames,'^\.','once'));
+	subdirs = subdirs(~ishidden);
+end;
 
 if ~options.SearchParentFirst,
 	for i=subdirs,


### PR DESCRIPTION
## Summary

Adds a `followHidden` option (default `false`) to both `findfilegroups` and `vlt.file.findfilegroups`. When `false`, subdirectories whose names begin with `.` (hidden directories) are no longer traversed during the recursive search. Setting `followHidden` to `true` restores the previous behavior.

## Details

- New `followHidden` option documented in both functions' help blocks.
- After collecting `subdirs`, any whose name begins with `.` are dropped from the recursion list when `followHidden` is false.
- The option propagates through recursive calls via the existing name/value-pair machinery, so it applies at every depth.

Note: `dirstrip` already removed `.`, `..`, `.DS_Store`, and `.git`, but other dotted directories (e.g. `.cache`) were previously traversed — those are now skipped by default.

https://claude.ai/code/session_01BfsQuhdpmQUSiLKSBe5qGF

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfsQuhdpmQUSiLKSBe5qGF)_